### PR TITLE
feat: Improve create resiliency

### DIFF
--- a/cluster/create.go
+++ b/cluster/create.go
@@ -14,6 +14,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	kstrings "github.com/jwilder/k3a/pkg/strings"
 
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -26,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/jwilder/k3a/pkg/retry"
 )
 
 type CreateArgs struct {
@@ -55,7 +59,7 @@ func createResourceGroup(ctx context.Context, subscriptionID, cluster, location 
 
 // createKeyVault creates a Key Vault and assigns roles
 func createKeyVault(ctx context.Context, subscriptionID, cluster, location, vnetNamePrefix, msiPrincipalID, callingPrincipalID string, cred *azidentity.DefaultAzureCredential, tenantID string) (string, error) {
-	keyVaultName := strings.ToLower(vnetNamePrefix + "kv" + kstrings.UniqueString(cluster))
+	keyVaultName := strings.ToLower(vnetNamePrefix + "kv" + kstrings.UniqueString(cluster, subscriptionID))
 	keyVaultClient, err := armkeyvault.NewVaultsClient(subscriptionID, cred, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Key Vault client: %w", err)
@@ -87,44 +91,73 @@ func createKeyVault(ctx context.Context, subscriptionID, cluster, location, vnet
 	keyVaultID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s", subscriptionID, cluster, keyVaultName)
 	certAdminRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/a4417e6f-fecd-4de8-b567-7b0420556985", subscriptionID)
 	certAdminRoleName := kstrings.DeterministicGUID(keyVaultID + msiPrincipalID + "a4417e6f-fecd-4de8-b567-7b0420556985")
-	if _, err = roleAssignmentsClient.Create(ctx, keyVaultID, certAdminRoleName, armauthorization.RoleAssignmentCreateParameters{
-		Properties: &armauthorization.RoleAssignmentProperties{
-			PrincipalID:      to.Ptr(msiPrincipalID),
-			RoleDefinitionID: to.Ptr(certAdminRoleDefID),
-		},
-	}, nil); err != nil {
-		return "", fmt.Errorf("failed to assign role to MSI: %w", err)
+	if err = retry.RetryWithDelays(ctx, []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}, classifyAzureRoleAssignmentError, func(ctx context.Context) error {
+		_, e := roleAssignmentsClient.Create(ctx, keyVaultID, certAdminRoleName, armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				PrincipalID:      to.Ptr(msiPrincipalID),
+				RoleDefinitionID: to.Ptr(certAdminRoleDefID),
+			},
+		}, nil)
+		return e
+	}); err != nil {
+		return "", fmt.Errorf("failed to assign role to MSI (cert admin): %w", err)
 	}
 	secretAdminRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/b86a8fe4-44ce-4948-aee5-eccb2c155cd7", subscriptionID)
 	secretAdminRoleName := kstrings.DeterministicGUID(keyVaultID + msiPrincipalID + "b86a8fe4-44ce-4948-aee5-eccb2c155cd7")
-	if _, err = roleAssignmentsClient.Create(ctx, keyVaultID, secretAdminRoleName, armauthorization.RoleAssignmentCreateParameters{
-		Properties: &armauthorization.RoleAssignmentProperties{
-			PrincipalID:      to.Ptr(msiPrincipalID),
-			RoleDefinitionID: to.Ptr(secretAdminRoleDefID),
-		},
-	}, nil); err != nil {
-		return "", fmt.Errorf("failed to assign role to MSI: %w", err)
+	if err = retry.RetryWithDelays(ctx, []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}, classifyAzureRoleAssignmentError, func(ctx context.Context) error {
+		_, e := roleAssignmentsClient.Create(ctx, keyVaultID, secretAdminRoleName, armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				PrincipalID:      to.Ptr(msiPrincipalID),
+				RoleDefinitionID: to.Ptr(secretAdminRoleDefID),
+			},
+		}, nil)
+		return e
+	}); err != nil {
+		return "", fmt.Errorf("failed to assign role to MSI (secret admin): %w", err)
 	}
 	certOfficerRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/14b46e9e-c2b7-41b4-b07b-48a6ebf60603", subscriptionID)
 	certOfficerRoleName := kstrings.DeterministicGUID(keyVaultID + msiPrincipalID + "14b46e9e-c2b7-41b4-b07b-48a6ebf60603")
-	if _, err = roleAssignmentsClient.Create(ctx, keyVaultID, certOfficerRoleName, armauthorization.RoleAssignmentCreateParameters{
-		Properties: &armauthorization.RoleAssignmentProperties{
-			PrincipalID:      to.Ptr(msiPrincipalID),
-			RoleDefinitionID: to.Ptr(certOfficerRoleDefID),
-		},
-	}, nil); err != nil {
+	if err = retry.RetryWithDelays(ctx, []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}, classifyAzureRoleAssignmentError, func(ctx context.Context) error {
+		_, e := roleAssignmentsClient.Create(ctx, keyVaultID, certOfficerRoleName, armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				PrincipalID:      to.Ptr(msiPrincipalID),
+				RoleDefinitionID: to.Ptr(certOfficerRoleDefID),
+			},
+		}, nil)
+		return e
+	}); err != nil {
 		return "", fmt.Errorf("failed to assign Key Vault Certificate Officer role to MSI: %w", err)
 	}
 	callingPrincipalRoleName := kstrings.DeterministicGUID(keyVaultID + callingPrincipalID + "b86a8fe4-44ce-4948-aee5-eccb2c155cd7")
-	if _, err = roleAssignmentsClient.Create(ctx, keyVaultID, callingPrincipalRoleName, armauthorization.RoleAssignmentCreateParameters{
-		Properties: &armauthorization.RoleAssignmentProperties{
-			PrincipalID:      to.Ptr(callingPrincipalID),
-			RoleDefinitionID: to.Ptr(secretAdminRoleDefID),
-		},
-	}, nil); err != nil {
+	if err = retry.RetryWithDelays(ctx, []time.Duration{10 * time.Second, 30 * time.Second, 60 * time.Second}, classifyAzureRoleAssignmentError, func(ctx context.Context) error {
+		_, e := roleAssignmentsClient.Create(ctx, keyVaultID, callingPrincipalRoleName, armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				PrincipalID:      to.Ptr(callingPrincipalID),
+				RoleDefinitionID: to.Ptr(secretAdminRoleDefID),
+			},
+		}, nil)
+		return e
+	}); err != nil {
 		return "", fmt.Errorf("failed to assign role to calling principal: %w", err)
 	}
 	return keyVaultName, nil
+}
+
+// classifyAzureRoleAssignmentError determines if a role assignment error is retriable (propagation / transient)
+func classifyAzureRoleAssignmentError(err error) bool { // # noqa: E501
+	if err == nil {
+		return false
+	}
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		sc := respErr.StatusCode
+		if sc == 404 || sc == 409 || sc == 429 || (sc >= 500 && sc < 600) {
+			return true
+		}
+		return false
+	}
+	// Unknown error type: be conservative and retry once
+	return true
 }
 
 // createManagedIdentity creates a user-assigned managed identity and returns its principal ID
@@ -278,7 +311,7 @@ func Create(args CreateArgs) error {
 	}
 
 	// Create Storage Account
-	storageName := strings.ToLower(vnetNamePrefix + "storage" + kstrings.UniqueString(cluster))
+	storageName := strings.ToLower(vnetNamePrefix + "storage" + kstrings.UniqueString(cluster, subscriptionID))
 	if err := createStorageAccount(ctx, subscriptionID, cluster, location, storageName, cred); err != nil {
 		return err
 	}
@@ -331,9 +364,10 @@ func Create(args CreateArgs) error {
 		}
 	}
 
-	clusterHash := kstrings.UniqueString(cluster)
+	clusterHash := kstrings.UniqueString(cluster, subscriptionID)
 	pgServerName := strings.ToLower(vnetNamePrefix + "pg" + clusterHash)
-	if err := createPostgresFlexibleServer(ctx, subscriptionID, cluster, location, vnetNamePrefix, "azureuser", postgresPassword, clusterHash, cred); err != nil {
+	pgServerLocation := location
+	if err := createPostgresFlexibleServer(ctx, subscriptionID, cluster, pgServerLocation, vnetNamePrefix, "azureuser", postgresPassword, pgServerName, cred); err != nil {
 		return fmt.Errorf("failed to create Postgres Flexible Server: %w", err)
 	}
 
@@ -472,8 +506,7 @@ func createVirtualNetwork(ctx context.Context, subscriptionID, resourceGroup, lo
 }
 
 // createPostgresFlexibleServer provisions an Azure PostgreSQL Flexible Server matching the Bicep module configuration
-func createPostgresFlexibleServer(ctx context.Context, subscriptionID, resourceGroup, location, vnetNamePrefix, adminUsername, adminPassword, clusterHash string, cred *azidentity.DefaultAzureCredential) error {
-	serverName := strings.ToLower(vnetNamePrefix + "pg" + clusterHash)
+func createPostgresFlexibleServer(ctx context.Context, subscriptionID, resourceGroup, location, vnetNamePrefix, adminUsername, adminPassword, serverName string, cred *azidentity.DefaultAzureCredential) error {
 	serversClient, err := armpostgresqlflexibleservers.NewServersClient(subscriptionID, cred, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create postgres servers client: %w", err)

--- a/cmd/k3a/kubeconfig.go
+++ b/cmd/k3a/kubeconfig.go
@@ -23,7 +23,7 @@ var kubeconfigCmd = &cobra.Command{
 			return fmt.Errorf("--cluster flag is required")
 		}
 		// Compute keyvault name from cluster name
-		clusterHash := kstrings.UniqueString(kubeconfigCluster)
+		clusterHash := kstrings.UniqueString(kubeconfigCluster, subscriptionID)
 		kubeconfigKeyVault := fmt.Sprintf("k3akv%s", clusterHash)
 		ctx := context.Background()
 		cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/cmd/k3a/loadbalancer.go
+++ b/cmd/k3a/loadbalancer.go
@@ -52,7 +52,7 @@ var ruleCreateCmd = &cobra.Command{
 
 		lbName, _ := cmd.Flags().GetString("lb-name")
 		if lbName == "" {
-			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster)) // Default LB name based on cluster
+			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster, subscriptionID)) // Default LB name based on cluster
 		}
 		lbRuleName, _ := cmd.Flags().GetString("rule-name")
 		lbFrontendPort, _ := cmd.Flags().GetInt("frontend-port")
@@ -91,7 +91,7 @@ var ruleListCmd = &cobra.Command{
 
 		lbName, _ := cmd.Flags().GetString("lb-name")
 		if lbName == "" {
-			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster)) // Default LB name based on cluster
+			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster, subscriptionID)) // Default LB name based on cluster
 		}
 		return rule.List(rule.ListRuleArgs{
 			SubscriptionID: subscriptionID,
@@ -116,7 +116,7 @@ var ruleDeleteCmd = &cobra.Command{
 
 		lbName, _ := cmd.Flags().GetString("lb-name")
 		if lbName == "" {
-			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster)) // Default LB name based on cluster
+			lbName = fmt.Sprintf("k3alb%s", kstrings.UniqueString(cluster, subscriptionID)) // Default LB name based on cluster
 		}
 		lbRuleName, _ := cmd.Flags().GetString("rule-name")
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,67 @@
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// RetryWithDelays # noqa: E501
+//
+// RetryWithDelays executes the provided operation function up to len(delays)+1 times (an initial attempt plus one retry per delay).
+// It waits for the corresponding delay element before each retry. A nil error from op stops immediately with success.
+// If isRetriable is non-nil and returns false for a given error, the retry loop stops early and that error is returned.
+// This helper is intentionally simple and deterministic so that callers (e.g., cluster/create.go key vault role assignments)
+// can specify exact propagation backoff sequences (10s, 30s, 60s) instead of exponential patterns.
+//
+// :param ctx: context for cancellation
+// :type ctx: context.Context
+// :param delays: slice of delays (e.g., []time.Duration{10*time.Second,30*time.Second,60*time.Second}) applied before subsequent attempts
+// :type delays: []time.Duration
+// :param isRetriable: optional classifier; if nil all errors are considered retriable, otherwise must return true to continue retrying
+// :type isRetriable: func(error) bool
+// :param op: the operation to execute; should be idempotent or safe to retry
+// :type op: func(context.Context) error
+// :return: final error if all attempts fail, else nil
+// :rtype: error
+//
+// Example:
+//
+//	import (
+//		"errors"
+//		"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+//	)
+//
+//	delays := []time.Duration{10*time.Second,30*time.Second,60*time.Second}
+//	isRetriable := func(err error) bool {
+//		var respErr interface{ StatusCode() int }
+//		if errors.As(err, &respErr) {
+//			sc := respErr.StatusCode()
+//			return sc == 404 || sc == 409 || sc == 429 || (sc >= 500 && sc < 600)
+//		}
+//		return true
+//	}
+//	retry.RetryWithDelays(ctx, delays, isRetriable, func(ctx context.Context) error { return doThing() })
+func RetryWithDelays(ctx context.Context, delays []time.Duration, isRetriable func(error) bool, op func(context.Context) error) error {
+	var err error
+	for attempt := 0; attempt <= len(delays); attempt++ {
+		if ctx.Err() != nil { // context cancelled or deadline exceeded
+			return ctx.Err()
+		}
+		err = op(ctx)
+		if err == nil {
+			return nil
+		}
+		if isRetriable != nil && !isRetriable(err) { // non-retriable
+			return err
+		}
+		if attempt == len(delays) { // no more retries
+			break
+		}
+		select {
+		case <-time.After(delays[attempt]):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return err
+}

--- a/pool/create.go
+++ b/pool/create.go
@@ -233,7 +233,7 @@ func Create(args CreatePoolArgs) error {
 		return err
 	}
 
-	clusterHash := kstrings.UniqueString(cluster)
+	clusterHash := kstrings.UniqueString(cluster, subscriptionID)
 
 	publicIPName := fmt.Sprintf("k3alb%s-publicip", clusterHash)
 	externalIP, err := getPublicIP(ctx, subscriptionID, cluster, publicIPName, cred)

--- a/pool/delete.go
+++ b/pool/delete.go
@@ -48,7 +48,7 @@ func Delete(args DeletePoolArgs) error {
 	}
 
 	// Compute clusterHash for consistent LB naming
-	clusterHash := kstrings.UniqueString(cluster)
+	clusterHash := kstrings.UniqueString(cluster, subscriptionID)
 	// Delete the backend pool from the load balancer
 	lbName := strings.ToLower("k3alb" + clusterHash)
 	backendPoolName := fmt.Sprintf("k3a-%s-backend-pool", poolName)


### PR DESCRIPTION
Global resources (KeyVault, Storage Acct, etc) were named only by a hash of the cluster name, which means the same cluster name could not be reused within a cloud. By including the subscription name in the resource name generation, we can now reuse cluster names across different subscriptions.

Role assignments to newly created MSIs can fail, since MSI takes a bit to propagate. Added retry logic to handle this delay.